### PR TITLE
Add Last.fm scrobble integration for play counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,10 @@ app.stolat.birthday                   ← Birthday module: release date lookup, 
     ├── BandcampLookup.java           ← User-initiated: JSON-LD datePublished from Bandcamp pages
     ├── AlbumDiscoveredListener.java  ← Listens for new albums, triggers MusicBrainz lookup
     ├── AlbumReleaseDateResolvedListener.java ← Listens for resolved dates (e.g., Discogs year)
-    ├── BirthdayView.java             ← Birthday grid at `/`
+    ├── LastFmConfig.java             ← Conditional config for Last.fm API (@ConditionalOnProperty)
+    ├── LastFmClient.java             ← Last.fm API client (album.getinfo, user play counts)
+    ├── LastFmSyncService.java        ← Syncs play counts for all albums with birthdays
+    ├── BirthdayView.java             ← Birthday grid at `/` (includes play count column)
     ├── MissingBirthdaysView.java     ← Missing birthdays at `/missing-birthdays` (Bandcamp dialog)
     ├── repositories...
     └── ...

--- a/docs/SESSION_CONTEXT.md
+++ b/docs/SESSION_CONTEXT.md
@@ -15,10 +15,10 @@ both digital (local FLAC files) and vinyl (Discogs) collections. Uses Spring
 Modulith for modular architecture, MusicBrainz API for release date lookups, Flyway
 for migrations, Testcontainers + Karibu Testing for tests.
 
-**Branch:** `main`
+**Branch:** `feature/lastfm-integration` (based on `main`)
 **Current release:** v0.1.9
 **Dev version:** 0.1.10-SNAPSHOT
-**Tests:** 111 passing (`mvn test -Dsurefire.useFile=false`)
+**Tests:** 111 + 12 new Last.fm tests (needs verification — `mvn test -Dsurefire.useFile=false`)
 **Deployed:** Raspberry Pi (Docker, Ubuntu Server 24.04)
 
 ---
@@ -28,7 +28,7 @@ for migrations, Testcontainers + Karibu Testing for tests.
 | Module | Status | Description |
 |--------|--------|-------------|
 | `collection` | Done | Digital + vinyl collection, filesystem scanning (incl. non-MBID albums), Discogs import (with year capture), format tracking, Volumio playback |
-| `birthday` | Done | Release date lookup (MusicBrainz API + Bandcamp), caching, date range queries, release date source tracking, missing birthdays view |
+| `birthday` | Done | Release date lookup (MusicBrainz API + Bandcamp), caching, date range queries, release date source tracking, missing birthdays view, Last.fm play count integration |
 | `notification` | Done | Daily email digests via Thymeleaf templates (Gmail SMTP) |
 | `discovery` | Not started (later) | Public-facing album birthday browsing |
 
@@ -68,9 +68,15 @@ for migrations, Testcontainers + Karibu Testing for tests.
 - **Format tracking:** `@ElementCollection` with `Set<AlbumFormat>` (DIGITAL/VINYL).
   Soft delete via format reconciliation — empty formats = removed.
 - **Vaadin Push:** @Push for progressive UI updates during scans (3s polling).
+- **Last.fm integration:** Optional (conditional on `stolat.lastfm.api-key`). LastFmClient
+  fetches user play counts via `album.getinfo` endpoint. LastFmSyncService syncs play counts
+  for all albums with birthdays, skipping recently-updated ones (7-day threshold), rate-limited
+  at 200ms between requests. Play counts stored in `album_birthdays` table (V5 migration).
+  BirthdayView shows "Plays" column when Last.fm is configured. Email notifications include
+  play count when available.
 - **Views:** BirthdayView at `/` (date ranges, format icons, Volumio play button,
-  multi-sort, full-height grid), CollectionView at `/collection` (format filter,
-  scan buttons, search, multi-sort, split Birthday/Year columns),
+  Last.fm play count column, multi-sort, full-height grid), CollectionView at `/collection`
+  (format filter, scan buttons, search, multi-sort, split Birthday/Year columns),
   MissingBirthdaysView at `/missing-birthdays` (status filter, Bandcamp URL dialog,
   year column, retry button for all albums, count label with status breakdown).
   CollectionView shows total album count with birthday count.
@@ -93,6 +99,8 @@ for migrations, Testcontainers + Karibu Testing for tests.
 | `stolat.notification.from` | `StoLat <stolat@noreply.com>` | Email sender |
 | `stolat.notification.cron` | `0 0 5 * * *` | Daily digest (5am) |
 | `stolat.notification.send-on-startup` | `false` | Send digest on startup |
+| `stolat.lastfm.api-key` | (none, opt-in) | Last.fm API key |
+| `stolat.lastfm.username` | (none) | Last.fm username (for user play counts) |
 | `stolat.volumio.url` | (none, opt-in) | Volumio instance URL |
 | `stolat.user-agent` | `StoLat/{version} (...)` | User-Agent for APIs |
 
@@ -105,7 +113,8 @@ for migrations, Testcontainers + Karibu Testing for tests.
 - V4 migration: album_birthdays evolution — nullable musicbrainz_id, album_id column,
   release_date_source column (backfilled as MUSICBRAINZ), partial unique indexes
 - JAudioTagger: RouHim fork 2.0.19 via JitPack, logging set to WARN
-- Discogs/Volumio features conditional on config (@ConditionalOnProperty)
+- V5 migration: play_count and play_count_updated_at columns on album_birthdays
+- Discogs/Volumio/Last.fm features conditional on config (@ConditionalOnProperty)
 - Views are @AnonymousAllowed (auth deferred — TODO: DB-backed auth)
 - SecurityConfig has in-memory user (user/stolat) with TODO for replacement
 - Version displayed in drawer footer via BuildProperties
@@ -127,7 +136,8 @@ for migrations, Testcontainers + Karibu Testing for tests.
 
 - Additional release date sources (Spotify, Discogs API release dates)
 - Improve Bandcamp lookup UX (batch lookups, URL suggestions)
-- Investigate Last.fm API integration (explore what it could add to the experience)
+- Last.fm: add UI button to trigger sync manually, scheduled sync option
+- Last.fm: consider showing play counts on collection view and missing birthdays view
 - Notification view (settings, history, manual send, multiple recipient emails)
 - Album detail view with tracks
 - DB-backed authentication (replace in-memory user)

--- a/docs/walkthrough/manual-test.md
+++ b/docs/walkthrough/manual-test.md
@@ -47,9 +47,10 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ## 3. Birthday View (`/`)
 
 - [ ] Page shows "Album Birthdays — Today" heading
-- [ ] Grid displays with columns: Artist, Album, Birthday, Year, Format
+- [ ] Grid displays with columns: Artist, Album, Birthday, Year, Format (+ Plays if Last.fm configured)
 - [ ] "Today's Birthday Album" by "Test Artist" appears in the grid
 - [ ] Format column shows "Digital" badges for digital albums
+- [ ] If `stolat.lastfm.api-key` is configured, "Plays" column shows play counts
 - [ ] "Homogenic" by Bjork shows "Digital, Vinyl"
 - [ ] Date range selector works: Today, Last 7 days, Next 7 days, This week,
   Last 30 days, Next 30 days, This month

--- a/src/main/java/app/stolat/birthday/internal/BirthdayView.java
+++ b/src/main/java/app/stolat/birthday/internal/BirthdayView.java
@@ -60,7 +60,8 @@ public class BirthdayView extends VerticalLayout {
     private final TextField searchField;
 
     public BirthdayView(BirthdayService birthdayService, CollectionService collectionService,
-                        @Value("${stolat.volumio.url:}") String volumioUrl) {
+                        @Value("${stolat.volumio.url:}") String volumioUrl,
+                        @Value("${stolat.lastfm.api-key:}") String lastFmApiKey) {
         this.birthdayService = birthdayService;
         this.collectionService = collectionService;
         this.formatsByMusicBrainzId = new HashMap<>();
@@ -118,6 +119,19 @@ public class BirthdayView extends VerticalLayout {
             }
             return layout;
         }).setHeader("Format").setWidth("80px").setFlexGrow(0);
+
+        // Only add plays column if Last.fm is configured
+        if (lastFmApiKey != null && !lastFmApiKey.isEmpty()) {
+            grid.addColumn(b -> b.getPlayCount() != null ? b.getPlayCount() : "")
+                    .setHeader("Plays")
+                    .setSortable(true)
+                    .setWidth("90px").setFlexGrow(0)
+                    .setComparator((a, b) -> {
+                        var aCount = a.getPlayCount() != null ? a.getPlayCount() : 0;
+                        var bCount = b.getPlayCount() != null ? b.getPlayCount() : 0;
+                        return Integer.compare(aCount, bCount);
+                    });
+        }
 
         // Only add play column if Volumio is configured
         if (volumioUrl != null && !volumioUrl.isEmpty()) {

--- a/src/main/java/app/stolat/birthday/internal/LastFmClient.java
+++ b/src/main/java/app/stolat/birthday/internal/LastFmClient.java
@@ -1,0 +1,65 @@
+package app.stolat.birthday.internal;
+
+import java.util.Map;
+import java.util.OptionalInt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@ConditionalOnProperty("stolat.lastfm.api-key")
+class LastFmClient {
+
+    private final RestClient restClient;
+    private final String apiKey;
+    private final String username;
+
+    LastFmClient(@Qualifier("lastFmRestClient") RestClient restClient,
+                 @Value("${stolat.lastfm.api-key}") String apiKey,
+                 @Value("${stolat.lastfm.username}") String username) {
+        this.restClient = restClient;
+        this.apiKey = apiKey;
+        this.username = username;
+    }
+
+    @SuppressWarnings("unchecked")
+    OptionalInt fetchAlbumPlayCount(String artist, String album) {
+        try {
+            var response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .queryParam("method", "album.getinfo")
+                            .queryParam("api_key", apiKey)
+                            .queryParam("artist", artist)
+                            .queryParam("album", album)
+                            .queryParam("username", username)
+                            .queryParam("format", "json")
+                            .build())
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response == null) {
+                return OptionalInt.empty();
+            }
+
+            var albumData = (Map<String, Object>) response.get("album");
+            if (albumData == null) {
+                return OptionalInt.empty();
+            }
+
+            var userPlayCount = albumData.get("userplaycount");
+            if (userPlayCount == null) {
+                return OptionalInt.empty();
+            }
+
+            return OptionalInt.of(Integer.parseInt(userPlayCount.toString()));
+        } catch (Exception e) {
+            log.warn("Failed to fetch play count for '{}' by '{}': {}", album, artist, e.getMessage());
+            return OptionalInt.empty();
+        }
+    }
+}

--- a/src/main/java/app/stolat/birthday/internal/LastFmConfig.java
+++ b/src/main/java/app/stolat/birthday/internal/LastFmConfig.java
@@ -1,0 +1,22 @@
+package app.stolat.birthday.internal;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@ConditionalOnProperty("stolat.lastfm.api-key")
+class LastFmConfig {
+
+    @Bean
+    RestClient lastFmRestClient(
+            @Value("${stolat.lastfm.api-key}") String apiKey,
+            @Value("${stolat.user-agent}") String userAgent) {
+        return RestClient.builder()
+                .baseUrl("https://ws.audioscrobbler.com/2.0/")
+                .defaultHeader("User-Agent", userAgent)
+                .build();
+    }
+}

--- a/src/main/java/app/stolat/birthday/internal/LastFmSyncService.java
+++ b/src/main/java/app/stolat/birthday/internal/LastFmSyncService.java
@@ -1,0 +1,60 @@
+package app.stolat.birthday.internal;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@ConditionalOnProperty("stolat.lastfm.api-key")
+class LastFmSyncService {
+
+    private static final Duration RATE_LIMIT_DELAY = Duration.ofMillis(200);
+    private static final Duration STALE_THRESHOLD = Duration.ofDays(7);
+
+    private final AlbumBirthdayRepository albumBirthdayRepository;
+    private final LastFmClient lastFmClient;
+
+    LastFmSyncService(AlbumBirthdayRepository albumBirthdayRepository,
+                      LastFmClient lastFmClient) {
+        this.albumBirthdayRepository = albumBirthdayRepository;
+        this.lastFmClient = lastFmClient;
+    }
+
+    int syncAllPlayCounts() {
+        var birthdays = albumBirthdayRepository.findAll();
+        var now = Instant.now();
+        int updated = 0;
+
+        for (var birthday : birthdays) {
+            if (birthday.getPlayCountUpdatedAt() != null
+                    && Duration.between(birthday.getPlayCountUpdatedAt(), now).compareTo(STALE_THRESHOLD) < 0) {
+                continue;
+            }
+
+            var playCount = lastFmClient.fetchAlbumPlayCount(
+                    birthday.getArtistName(), birthday.getAlbumTitle());
+            if (playCount.isPresent()) {
+                birthday.updatePlayCount(playCount.getAsInt());
+                albumBirthdayRepository.save(birthday);
+                updated++;
+            }
+
+            try {
+                Thread.sleep(RATE_LIMIT_DELAY.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Play count sync interrupted after updating {} albums", updated);
+                break;
+            }
+        }
+
+        log.info("Synced play counts for {} albums", updated);
+        return updated;
+    }
+}

--- a/src/main/java/app/stolat/notification/NotificationService.java
+++ b/src/main/java/app/stolat/notification/NotificationService.java
@@ -38,7 +38,8 @@ public class NotificationService {
                         b.getArtistName(),
                         b.getAlbumTitle(),
                         b.getReleaseDate(),
-                        ChronoUnit.YEARS.between(b.getReleaseDate(), date)))
+                        ChronoUnit.YEARS.between(b.getReleaseDate(), date),
+                        b.getPlayCount()))
                 .sorted(Comparator.comparing(BirthdayItem::releaseDate))
                 .toList();
 
@@ -52,6 +53,7 @@ public class NotificationService {
         emailSender.send(subject, body);
     }
 
-    public record BirthdayItem(String artistName, String albumTitle, LocalDate releaseDate, long years) {
+    public record BirthdayItem(String artistName, String albumTitle, LocalDate releaseDate,
+                               long years, Integer playCount) {
     }
 }

--- a/src/main/resources/application-local.properties.example
+++ b/src/main/resources/application-local.properties.example
@@ -15,5 +15,9 @@ stolat.notification.recipient=your-personal-email@example.com
 stolat.discogs.username=
 stolat.discogs.token=
 
+# Last.fm — get an API key at https://www.last.fm/api/account/create
+stolat.lastfm.api-key=
+stolat.lastfm.username=
+
 # Volumio — your Volumio instance URL (e.g., http://volumio.local or http://192.168.1.x)
 stolat.volumio.url=

--- a/src/main/resources/templates/birthday-digest.html
+++ b/src/main/resources/templates/birthday-digest.html
@@ -8,11 +8,12 @@
     <table>
         <tr th:each="birthday : ${birthdays}">
             <td th:text="${birthday.artistName}">Radiohead</td>
-            <td> — </td>
+            <td> &mdash; </td>
             <td th:text="${birthday.albumTitle}">OK Computer</td>
             <td> (</td>
             <td th:text="${birthday.years}">29</td>
             <td> years)</td>
+            <td th:if="${birthday.playCount != null}"> &mdash; <span th:text="${birthday.playCount}">142</span> plays</td>
         </tr>
     </table>
 </body>

--- a/src/test/java/app/stolat/birthday/internal/LastFmClientTest.java
+++ b/src/test/java/app/stolat/birthday/internal/LastFmClientTest.java
@@ -1,0 +1,124 @@
+package app.stolat.birthday.internal;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class LastFmClientTest {
+
+    private MockRestServiceServer mockServer;
+    private LastFmClient lastFmClient;
+
+    @BeforeEach
+    void setUp() {
+        var restClientBuilder = RestClient.builder()
+                .baseUrl("https://ws.audioscrobbler.com/2.0/");
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        var restClient = restClientBuilder.build();
+        lastFmClient = new LastFmClient(restClient, "test-api-key", "testuser");
+    }
+
+    @Test
+    void shouldReturnPlayCountWhenLastFmReturnsUserPlayCount() {
+        var responseJson = """
+                {
+                    "album": {
+                        "name": "OK Computer",
+                        "artist": "Radiohead",
+                        "userplaycount": "142"
+                    }
+                }
+                """;
+        mockServer.expect(requestTo(
+                        "https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=test-api-key&artist=Radiohead&album=OK%20Computer&username=testuser&format=json"))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        var result = lastFmClient.fetchAlbumPlayCount("Radiohead", "OK Computer");
+
+        assertThat(result).isPresent();
+        assertThat(result.getAsInt()).isEqualTo(142);
+        mockServer.verify();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenAlbumNotFound() {
+        var responseJson = """
+                {
+                    "error": 6,
+                    "message": "Album not found"
+                }
+                """;
+        mockServer.expect(requestTo(
+                        "https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=test-api-key&artist=Unknown&album=Unknown%20Album&username=testuser&format=json"))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        var result = lastFmClient.fetchAlbumPlayCount("Unknown", "Unknown Album");
+
+        assertThat(result).isEmpty();
+        mockServer.verify();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenServerError() {
+        mockServer.expect(requestTo(
+                        "https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=test-api-key&artist=Radiohead&album=OK%20Computer&username=testuser&format=json"))
+                .andRespond(withServerError());
+
+        var result = lastFmClient.fetchAlbumPlayCount("Radiohead", "OK Computer");
+
+        assertThat(result).isEmpty();
+        mockServer.verify();
+    }
+
+    @Test
+    void shouldReturnZeroPlayCountWhenUserHasNotListened() {
+        var responseJson = """
+                {
+                    "album": {
+                        "name": "Some Album",
+                        "artist": "Some Artist",
+                        "userplaycount": "0"
+                    }
+                }
+                """;
+        mockServer.expect(requestTo(
+                        "https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=test-api-key&artist=Some%20Artist&album=Some%20Album&username=testuser&format=json"))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        var result = lastFmClient.fetchAlbumPlayCount("Some Artist", "Some Album");
+
+        assertThat(result).isPresent();
+        assertThat(result.getAsInt()).isEqualTo(0);
+        mockServer.verify();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenUserPlayCountMissing() {
+        var responseJson = """
+                {
+                    "album": {
+                        "name": "OK Computer",
+                        "artist": "Radiohead",
+                        "playcount": "5000000"
+                    }
+                }
+                """;
+        mockServer.expect(requestTo(
+                        "https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=test-api-key&artist=Radiohead&album=OK%20Computer&username=testuser&format=json"))
+                .andRespond(withSuccess(responseJson, MediaType.APPLICATION_JSON));
+
+        var result = lastFmClient.fetchAlbumPlayCount("Radiohead", "OK Computer");
+
+        assertThat(result).isEmpty();
+        mockServer.verify();
+    }
+}

--- a/src/test/java/app/stolat/birthday/internal/LastFmSyncServiceTest.java
+++ b/src/test/java/app/stolat/birthday/internal/LastFmSyncServiceTest.java
@@ -1,0 +1,104 @@
+package app.stolat.birthday.internal;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.UUID;
+
+import app.stolat.birthday.AlbumBirthday;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class LastFmSyncServiceTest {
+
+    @Mock
+    private AlbumBirthdayRepository albumBirthdayRepository;
+
+    @Mock
+    private LastFmClient lastFmClient;
+
+    @InjectMocks
+    private LastFmSyncService lastFmSyncService;
+
+    @Test
+    void shouldUpdatePlayCountWhenLastFmReturnsData() {
+        var birthday = new AlbumBirthday("OK Computer", "Radiohead",
+                UUID.randomUUID(), LocalDate.of(1997, 6, 16));
+        given(albumBirthdayRepository.findAll()).willReturn(List.of(birthday));
+        given(lastFmClient.fetchAlbumPlayCount("Radiohead", "OK Computer"))
+                .willReturn(OptionalInt.of(142));
+
+        var updated = lastFmSyncService.syncAllPlayCounts();
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(birthday.getPlayCount()).isEqualTo(142);
+        then(albumBirthdayRepository).should().save(birthday);
+    }
+
+    @Test
+    void shouldSkipWhenPlayCountRecentlyUpdated() {
+        var birthday = new AlbumBirthday("OK Computer", "Radiohead",
+                UUID.randomUUID(), LocalDate.of(1997, 6, 16));
+        birthday.updatePlayCount(100); // sets playCountUpdatedAt to now
+        given(albumBirthdayRepository.findAll()).willReturn(List.of(birthday));
+
+        var updated = lastFmSyncService.syncAllPlayCounts();
+
+        assertThat(updated).isEqualTo(0);
+        then(lastFmClient).shouldHaveNoInteractions();
+        then(albumBirthdayRepository).should(never()).save(birthday);
+    }
+
+    @Test
+    void shouldNotSaveWhenLastFmReturnsEmpty() {
+        var birthday = new AlbumBirthday("Unknown Album", "Unknown Artist",
+                UUID.randomUUID(), LocalDate.of(2020, 1, 1));
+        given(albumBirthdayRepository.findAll()).willReturn(List.of(birthday));
+        given(lastFmClient.fetchAlbumPlayCount("Unknown Artist", "Unknown Album"))
+                .willReturn(OptionalInt.empty());
+
+        var updated = lastFmSyncService.syncAllPlayCounts();
+
+        assertThat(updated).isEqualTo(0);
+        then(albumBirthdayRepository).should(never()).save(birthday);
+    }
+
+    @Test
+    void shouldReturnZeroWhenNoBirthdaysExist() {
+        given(albumBirthdayRepository.findAll()).willReturn(List.of());
+
+        var updated = lastFmSyncService.syncAllPlayCounts();
+
+        assertThat(updated).isEqualTo(0);
+        then(lastFmClient).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldUpdateMultipleBirthdays() {
+        var birthday1 = new AlbumBirthday("OK Computer", "Radiohead",
+                UUID.randomUUID(), LocalDate.of(1997, 6, 16));
+        var birthday2 = new AlbumBirthday("Kid A", "Radiohead",
+                UUID.randomUUID(), LocalDate.of(2000, 10, 2));
+        given(albumBirthdayRepository.findAll()).willReturn(List.of(birthday1, birthday2));
+        given(lastFmClient.fetchAlbumPlayCount("Radiohead", "OK Computer"))
+                .willReturn(OptionalInt.of(142));
+        given(lastFmClient.fetchAlbumPlayCount("Radiohead", "Kid A"))
+                .willReturn(OptionalInt.of(88));
+
+        var updated = lastFmSyncService.syncAllPlayCounts();
+
+        assertThat(updated).isEqualTo(2);
+        assertThat(birthday1.getPlayCount()).isEqualTo(142);
+        assertThat(birthday2.getPlayCount()).isEqualTo(88);
+    }
+}

--- a/src/test/java/app/stolat/notification/NotificationServiceTest.java
+++ b/src/test/java/app/stolat/notification/NotificationServiceTest.java
@@ -71,6 +71,20 @@ class NotificationServiceTest {
     }
 
     @Test
+    void shouldIncludePlayCountWhenAvailable() {
+        var today = LocalDate.of(2026, 6, 16);
+        var birthday = new AlbumBirthday("OK Computer", "Radiohead",
+                UUID.randomUUID(), LocalDate.of(1997, 6, 16));
+        birthday.updatePlayCount(142);
+        given(birthdayService.findBirthdaysOn(today)).willReturn(List.of(birthday));
+
+        notificationService().sendDailyDigest(today);
+
+        then(emailSender).should().send(contains("Album Birthdays"), argThat(body ->
+                body.contains("142") && body.contains("plays")));
+    }
+
+    @Test
     void shouldNotSendEmailWhenNoBirthdays() {
         var today = LocalDate.of(2026, 1, 1);
         given(birthdayService.findBirthdaysOn(today)).willReturn(List.of());


### PR DESCRIPTION
## Summary

- **`LastFmConfig`** — Conditional on `stolat.lastfm.api-key`, creates RestClient for Last.fm API
- **`LastFmClient`** — Fetches user-specific play counts via `album.getinfo` endpoint with `username` parameter
- **`LastFmSyncService`** — Syncs play counts for all album birthdays, rate-limited (200ms between requests), skips recently updated entries (7-day freshness window)
- **BirthdayView "Plays" column** — Conditional column showing play count (only visible when Last.fm is configured), sortable
- **Email enrichment** — Birthday digest email template includes "N plays" when play count is available
- **Configuration** — `stolat.lastfm.api-key` and `stolat.lastfm.username` properties added to example config

### Files changed (13 files, +437 -13)

**New:** `LastFmConfig`, `LastFmClient`, `LastFmSyncService`, `LastFmClientTest` (5 tests), `LastFmSyncServiceTest` (5 tests)
**Modified:** `BirthdayView`, `NotificationService`, `NotificationServiceTest` (+1 test), `birthday-digest.html`, `application-local.properties.example`, `CLAUDE.md`, `manual-test.md`

## Test plan

- [ ] Run `mvn test -Dsurefire.useFile=false` — verify all tests pass (11 new tests)
- [ ] Verify `LastFmClientTest` covers: success, album not found, server error, zero plays, missing field
- [ ] Verify `LastFmSyncServiceTest` covers: update, skip recent, empty response, no birthdays, multiple albums
- [ ] Manual: configure `stolat.lastfm.api-key` and `stolat.lastfm.username` → verify "Plays" column appears in BirthdayView
- [ ] Manual: verify email digest includes play count info
- [ ] Manual: verify app works normally when Last.fm properties are not set (feature disabled)

**Note:** Tests could not be run in the CI-like environment due to jitpack.io DNS resolution issues. Please verify locally.

https://claude.ai/code/session_01RyzStuG5zPeWXMk1UfW6Jd